### PR TITLE
A fix for jive-sdk - TypeError: path must be a string exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
     "name": "grunt-jive-ps",
-    "version": "0.0.1",
+    "version": "0.0.2",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/jivesoftware/grunt-jive-ps.git"
+    },
     "dependencies": {
-        "grunt": "~0.4.4"
+        "grunt": "~0.4.4",
+        "jive-sdk": ">0.1.189"
     },
     "devDependencies": {
         "grunt-contrib-jshint": "0.10.0"

--- a/tasks/create_extension.js
+++ b/tasks/create_extension.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
 
         jive.service.init({use: function() {}, all: function(){}}).then(function() {
 
-            jive.service.extensions().prepare('', "tiles", "apps", "cartridges", "storages").done(function(){
+            jive.service.extensions().prepare('', "tiles", "apps", "cartridges", "storages", "services").done(function(){
                 process.chdir(originalCwd);
                 process.nextTick(function() {
                     done();


### PR DESCRIPTION
A fix to resolve the following exception:

[2015-07-06 10:24:01.190] [ERROR] jive-sdk - TypeError: path must be a string
   at fs.exists (fs.js:166:11)
   at Object.exports.fsexists (/Users/kavan.puranik/projects/jive-addons/author-change/node_modules/jive-sdk/jive-sdk-api/lib/util/jiveutil.js:134:5)
   at getServices (/Users/kavan.puranik/projects/jive-addons/author-change/node_modules/jive-sdk/jive-sdk-service/lib/extension/extension.js:564:22)
   at /Users/kavan.puranik/projects/jive-addons/author-change/node_modules/jive-sdk/jive-sdk-service/lib/extension/extension.js:373:20
   at processImmediate [as _immediateCallback](timers.js:345:15)
From previous event:
   at Object.exports.prepare (/Users/kavan.puranik/projects/jive-addons/author-change/node_modules/jive-sdk/jive-sdk-service/lib/extension/extension.js:139:8)
   at /Users/kavan.puranik/projects/jive-addons/author-change/node_modules/grunt-jive-ps/tasks/create_extension.js:16:39
   at processImmediate [as _immediateCallback](timers.js:345:15)
Fatal error: TypeError: path must be a string
